### PR TITLE
fix #30: allow optional "stop" field for oai

### DIFF
--- a/llama.cpp/server/server.cpp
+++ b/llama.cpp/server/server.cpp
@@ -2400,9 +2400,7 @@ json oaicompat_completion_params_parse(
     }
 
     // Handle 'stop' field
-    if (body["stop"].is_null()) {
-        llama_params["stop"] = json::array({});
-    } else if (body["stop"].is_string()) {
+    if (body.contains("stop") && body["stop"].is_string()) {
         llama_params["stop"] = json::array({body["stop"].get<std::string>()});
     } else {
         llama_params["stop"] = json_value(body, "stop", json::array());


### PR DESCRIPTION
Fix #30 r? @ggerganov 

Previously omitting "stop" asserts:
```
curl http://localhost:8080/v1/chat/completions -H "Content-Type: application/json" -d '{
  "messages": [{
    "role": "user",
    "content": "Write a limerick about python exceptions"
  }]
}'
```
`llama.cpp/server/json.h:21313: assert(it != m_value.object->end()) failed`