### PR TITLE
Fix irrelevant bounds check in cuda.c

### DIFF
--- a/llamafile/cuda.c
+++ b/llamafile/cuda.c
@@ -394,8 +394,8 @@ static bool ExtractCudaDso(char dso[static PATH_MAX]) {
 
     // see if prebuilt dso is bundled in zip assets
     char zip[80];
-    strlcpy(zip, "/zip/ggml-cuda.", PATH_MAX);
-    strlcat(zip, GetDsoExtension(), PATH_MAX);
+    strlcpy(zip, "/zip/ggml-cuda.", sizeof(zip));
+    strlcat(zip, GetDsoExtension(), sizeof(zip));
     if (!FileExists(zip)) {
         tinyprint(2, "prebuilt binary ", zip, " not found\n", NULL);
         return false;


### PR DESCRIPTION
May as well be `strcpy` and `strcat` in this case, but having the wrong size looks weird.