### PR TITLE
include ngl parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ For Windows users, here's an example for the Mistral LLM:
 ```sh
 curl -L -o llamafile.exe https://github.com/Mozilla-Ocho/llamafile/releases/download/0.6/llamafile-0.6
 curl -L -o mistral.gguf https://huggingface.co/TheBloke/Mistral-7B-Instruct-v0.1-GGUF/resolve/main/mistral-7b-instruct-v0.1.Q4_K_M.gguf
-./llamafile.exe -m mistral.gguf
+./llamafile.exe -m mistral.gguf -ngl 9999
 ```
 
 Windows users may need to change `./llamafile.exe` to `.\llamafile.exe`


### PR DESCRIPTION
Without this parameter the default Windows case is WAY slower for those who have a graphics card.