### PR TITLE
Allow setting `PREFIX ?= /my/path make install`

### DIFF
--- a/build/config.mk
+++ b/build/config.mk
@@ -1,7 +1,7 @@
 #-*-mode:makefile-gmake;indent-tabs-mode:t;tab-width:8;coding:utf-8-*-┐
 #── vi: set noet ft=make ts=8 sw=8 fenc=utf-8 :vi ────────────────────┘
 
-PREFIX = /usr/local
+PREFIX ?= /usr/local
 COSMOCC = .cosmocc/3.3.2
 TOOLCHAIN = $(COSMOCC)/bin/cosmo
 


### PR DESCRIPTION
With llm libraries and tools progressing quickly, I am more confident installing stuff in non-`/usr` paths. I guess others too.

This would allow installations like `PREFIX=$HOME/local make install`

