### PR TITLE
Remove automagic llava if prompt contains HTML img [#288]

### DIFF
--- a/llama.cpp/main/main.cpp
+++ b/llama.cpp/main/main.cpp
@@ -152,8 +152,7 @@ int main(int argc, char ** argv) {
     llama_log_set(llama_log_callback_logTee, nullptr);
 #endif // LOG_DISABLE_LOGS
 
-    if (!params.image.empty() ||
-        params.prompt.find("<img src=\"") != std::string::npos) {
+    if (!params.image.empty()) {
         return llava_cli(argc, argv, &params);
     }
 


### PR DESCRIPTION
This PR simply removes the feature.

Maybe a CLI flag to enable or disable would be appropriate, or perhaps I am misunderstanding the feature and there is a different way to make it better.

https://github.com/Mozilla-Ocho/llamafile/issues/288