### PR TITLE
Avoid bank conflicts in shared memory via duplication

### DIFF
--- a/llamafile/tinyblas.cu
+++ b/llamafile/tinyblas.cu
@@ -596,9 +596,9 @@ static tinyblasStatus_t tinyblasGBE_launch(tinyblasHandle_t handle, tinyblasOper
                                            WORD alpha, const SRC *const *Aarray, int lda,
                                            const SRC *const *Barray, int ldb, WORD beta,
                                            DST *const *Carray, int ldc, int batchCount) {
-    constexpr int BM = 16;
-    constexpr int BN = 16;
-    constexpr int TM = 4;
+    constexpr int BM = 24;
+    constexpr int BN = 12;
+    constexpr int TM = 8;
     constexpr int TN = 4;
     dim3 blocks(CEIL_DIV(m, BM), CEIL_DIV(n, BN), batchCount);
     tinyblasGBE_entry<BM, BN, TM, TN><<<blocks, THREAD_COUNT, 0, handle->stream>>>(
@@ -738,10 +738,10 @@ static tinyblasStatus_t tinyblasGSBE_launch(tinyblasHandle_t handle, tinyblasOpe
                                             WORD alpha, const SRC *A, int lda, long long strideA,
                                             const SRC *B, int ldb, long long strideB, WORD beta,
                                             DST *C, int ldc, long long strideC, int batchCount) {
-    constexpr int BM = 16;
-    constexpr int BN = 16;
-    constexpr int TM = 4;
-    constexpr int TN = 4;
+    constexpr int BM = 32;
+    constexpr int BN = 8;
+    constexpr int TM = 8;
+    constexpr int TN = 2;
     constexpr int BK = THREAD_COUNT;
     dim3 blocks(CEIL_DIV(m, BM), CEIL_DIV(n, BN), batchCount);
     if ((beta == 0 && //

--- a/llamafile/tinyblas.cu
+++ b/llamafile/tinyblas.cu
@@ -592,10 +592,10 @@ static tinyblasStatus_t tinyblasGBE_launch(tinyblasHandle_t handle, tinyblasOper
                                            WORD alpha, const SRC *const *Aarray, int lda,
                                            const SRC *const *Barray, int ldb, WORD beta,
                                            DST *const *Carray, int ldc, int batchCount) {
-    constexpr int BM = 32;
-    constexpr int BN = 32;
-    constexpr int TM = 2;
-    constexpr int TN = 8;
+    constexpr int BM = 16;
+    constexpr int BN = 16;
+    constexpr int TM = 4;
+    constexpr int TN = 4;
     dim3 blocks(CEIL_DIV(m, BM), CEIL_DIV(n, BN), batchCount);
     tinyblasGBE_entry<BM, BN, TM, TN><<<blocks, THREAD_COUNT, 0, handle->stream>>>(
         transa, transb, m, n, k, alpha, Aarray, lda, Barray, ldb, beta, Carray, ldc, batchCount);
@@ -734,10 +734,10 @@ static tinyblasStatus_t tinyblasGSBE_launch(tinyblasHandle_t handle, tinyblasOpe
                                             WORD alpha, const SRC *A, int lda, long long strideA,
                                             const SRC *B, int ldb, long long strideB, WORD beta,
                                             DST *C, int ldc, long long strideC, int batchCount) {
-    constexpr int BM = 32;
-    constexpr int BN = 32;
-    constexpr int TM = 2;
-    constexpr int TN = 8;
+    constexpr int BM = 16;
+    constexpr int BN = 16;
+    constexpr int TM = 4;
+    constexpr int TN = 4;
     constexpr int BK = THREAD_COUNT;
     dim3 blocks(CEIL_DIV(m, BM), CEIL_DIV(n, BN), batchCount);
     if ((beta == 0 && //

--- a/llamafile/tinyblas.cu
+++ b/llamafile/tinyblas.cu
@@ -125,7 +125,7 @@ static __device__ void matmul_block2d(tinyblasOperation_t transa, tinyblasOperat
                     As[BK * i + th][ip] = 0;
         for (int i = 0; i < BM && (ll + th < k || ksafe) && (ii + i < m || msafe); ++i)
             for(int ip = 0; ip < BN / TN; ++ip)
-                As[BM * th + i][ip] = A[transa ? lda * (ii + i) + (ll + th) : lda * (ll + th) + (ii + i)];
+                As[BK * i + th][ip] = A[transa ? lda * (ii + i) + (ll + th) : lda * (ll + th) + (ii + i)];
 
         if (!ksafe || !nsafe)
             for (int j = 0; j < BN; ++j)
@@ -139,7 +139,7 @@ static __device__ void matmul_block2d(tinyblasOperation_t transa, tinyblasOperat
 
         for (int l = 0; l < BK; ++l) {
             for (int j = 0; j < TM; ++j)
-                At[j] = As[BM * l + TM * ti + j][tj];
+                At[j] = As[l + BK * (TM * ti + j)][tj];
             for (int h = 0; h < TN; ++h)
                 Bt[h] = Bs[BN * l + TN * tj + h][ti];
             for (int j = 0; j < TM; ++j) {


### PR DESCRIPTION
This was an experiment to see if we could minimize the amount of bank conflicts in `As`/`Bs` via duplication.
I don't think this results in better performance, but perhaps this can be improved to do so.