### PR TITLE
use LLAMAFILE_GPU_ERROR instead of LLAMAFILE_GPU_DISABLE for invalid GPU flag error

### DIFF
--- a/llama.cpp/server/server.cpp
+++ b/llama.cpp/server/server.cpp
@@ -2504,7 +2504,7 @@ static void server_params_parse(int argc, char **argv, server_params &sparams,
                 break;
             }
             FLAG_gpu = llamafile_gpu_parse(argv[i]);
-            if (FLAG_gpu == -1)
+            if (FLAG_gpu == -2)
             {
                 fprintf(stderr, "error: invalid --gpu flag value: %s\n", argv[i]);
                 exit(1);


### PR DESCRIPTION
In the GPU argument parsing of the llama.cpp server, the FLAG_gpu is considered an error if it is equal to -1.
However the correct value of error should be -2 according to:
https://github.com/Mozilla-Ocho/llamafile/blob/9c53c272650bb84f3d6fb66aa0dd0fb20f92b18c/llamafile/llamafile.h#L34