### PR TITLE
Detect search query to start webchat

### DIFF
--- a/llama.cpp/server/public/index.html
+++ b/llama.cpp/server/public/index.html
@@ -1001,6 +1001,10 @@
     }
 
     function App(props) {
+      useEffect(() => {
+        const query = new URLSearchParams(location.search).get("q");
+        if (query) chat(query);
+      }, []);
 
       return html`
         <div class="mode-${session.value.type}">


### PR DESCRIPTION
Like https://github.com/ggerganov/llama.cpp/pull/6554 to support http://localhost:8080/?q=prompt like https://chat.openai.com/?q=prompt starting a chat but without the index.html.hpp nor fix to api_url not applicable here.

(cherry picked from commit ggerganov/llama.cpp@400d5d722d7edf7de0cf24a18c42b183c65047d2)