### PR TITLE
More conservative strong/em markdown matcher

### DIFF
--- a/llama.cpp/server/public/index.html
+++ b/llama.cpp/server/public/index.html
@@ -1121,8 +1121,8 @@
 
         // Headlines, emphasis and line breaks
         .replace(/^#{1,6} (.*)$/gim, '<h3>$1</h3>')
-        .replace(/(__|\*\*)(.*?)\1/g, '<strong>$2</strong>')
-        .replace(/(_|\*)(.*?)\1/g, '<em>$2</em>')
+        .replace(/(^|\s)(__|\*\*)(.*?)\2($|\s|[.?!])/g, '$1<strong>$3</strong>$4')
+        .replace(/(^|\s)(_|\*)(.*?)\2($|\s|[.?!])/g, '$1<em>$3</em>$4')
         .replace(/\n/gim, '<br />')
 
         // Paste the extracted blocks back in again


### PR DESCRIPTION
Both matchers are now constrained so that they will only be transformed if the left-hand characters are the start of the text or preceeded by whitespace, and the right-hand characters are the end of the text or followed by whitespace or a punctuation mark.

This misses some cases, e.g. emphasis inside of parantheticals, but has better behavior with e.g. underscores in function names outside of code blocks.

Fixes #317.