### PR TITLE
Fix get_amd_offload_arch_flag so it will match offload-arch types having alphanumeric names.

### DIFF
--- a/llamafile/cuda.c
+++ b/llamafile/cuda.c
@@ -205,6 +205,93 @@ static bool get_rocm_bin_path(char path[static PATH_MAX], const char *bin) {
     }
 }
 
+struct StringListEntry {
+    char *string;
+    struct StringListEntry *next;
+};
+
+struct StringList {
+    struct StringListEntry *head;
+    struct StringListEntry *tail;
+    size_t length;
+};
+
+void AddStringToStringList(struct StringList *string_list, char *string, size_t string_length) {
+    struct StringListEntry *new_entry = malloc(sizeof(struct StringListEntry));
+    new_entry->string = malloc(sizeof(char) * (string_length + 1));
+    strncpy(new_entry->string, string, string_length);
+    new_entry->string[string_length] = '\0';
+    new_entry->next = NULL;
+    if (string_list->head == NULL) {
+        string_list->head = new_entry;
+    } else {
+        string_list->tail->next = new_entry;
+    }
+    string_list->tail = new_entry;
+    ++string_list->length;
+}
+
+void CopyStringListToStringArray(struct StringList *string_list, char ***string_array) {
+    *string_array = malloc(sizeof(char *) * string_list->length);
+    struct StringListEntry *current = string_list->head;
+    int i = 0;
+    while (current != NULL) {
+        (*string_array)[i] = current->string;
+        current = current->next;
+        ++i;
+    }
+}
+
+void PrintStringList(struct StringList* string_list) {
+    struct StringListEntry* current = string_list->head;
+    printf("[");
+    while (current != NULL) {
+        printf("%s", current->string);
+        if (current != string_list->tail) {
+            printf(",");
+        }
+        current = current->next;
+    }
+    printf("]");
+}
+
+void PrintStringArray(char** string_list, size_t length) {
+    printf("[");
+    for (int i = 0; i < length; ++i) {
+        printf("%s", string_list[i]);
+        if (i != length - 1) {
+            printf(",");
+        }
+    }
+    printf("]");
+}
+
+int RemoveDuplicatesFromStringArray(char **strings, int num_strings) {
+    if (num_strings == 1) {
+        return 1;
+    }
+    int tail = 0;
+    for (int current = 1; current < num_strings; ++current) {
+        if (strcmp(strings[tail], strings[current]) != 0) {
+            strings[tail + 1] = strings[current];
+            ++tail;
+        } else {
+            strings[current] = NULL;
+        }
+    }
+    return tail + 1;
+}
+
+void FreeStringList(struct StringList* string_list) {
+    struct StringListEntry* current = string_list->head;
+    while (current != NULL) {
+        struct StringListEntry* next = current->next;
+        free(current->string);
+        free(current);
+        current = next;
+    }
+}
+
 // Returns word-encoded array of 16-bit gfxXXXX gcnArchName numbers.
 static bool get_amd_offload_arch_flag(char out[static 64]) {
 
@@ -245,10 +332,11 @@ static bool get_amd_offload_arch_flag(char out[static 64]) {
 
     // Parse program output to word-encoded array.
     int rc;
-    int a = 0;
     int t = 0;
     char buf[512];
-    unsigned long archs = 0;
+    char name[64] = {'g','f','x'};
+    int j = 3;
+    struct StringList name_list = {NULL, NULL, 0};
     while ((rc = read(pipefds[0], buf, sizeof(buf))) > 0) {
         for (int i = 0; i < rc; ++i) {
             switch (t) {
@@ -265,30 +353,18 @@ static bool get_amd_offload_arch_flag(char out[static 64]) {
             case 2:
                 if (buf[i] == 'x') {
                     t = 3;
-                    a = 0;
                 } else {
                     t = 0;
                 }
                 break;
             case 3:
-                if (isdigit(buf[i])) {
-                    a *= 10;
-                    a += buf[i] - '0';
+                if (isalnum(buf[i])) {
+                    name[j] = buf[i];
+                    ++j;
                 } else {
+                    AddStringToStringList(&name_list, name, j);
                     t = 0;
-                    if ((a & 0xffff) && (a & 0xffff) == a) {
-                        a &= 0xffff;
-                        bool dupe = false;
-                        for (int j = 0; j < 4; ++j) {
-                            if (((archs >> (j * 16)) & 0xffff) == a) {
-                                dupe = true;
-                            }
-                        }
-                        if (!dupe) {
-                            archs <<= 16;
-                            archs |= a;
-                        }
-                    }
+                    j = 3;
                 }
                 break;
             default:
@@ -312,18 +388,23 @@ static bool get_amd_offload_arch_flag(char out[static 64]) {
     }
 
     // Serialize value for --offload-arch=LIST flag.
-    if (!archs) {
+    if (name_list.length == 0) {
         tinylog(__func__, ": warning: hipInfo output didn't list any graphics cards\n", NULL);
         return false;
     }
-    bool gotsome = false;
     char *p = stpcpy(out, "--offload-arch=");
-    do {
-        if (gotsome)
+    char** names = NULL;
+
+    CopyStringListToStringArray(&name_list, &names);
+    int num_names = RemoveDuplicatesFromStringArray(names, name_list.length);
+    for (int i = 0; i < num_names; ++i) {
+        if (i > 0)
             *p++ = ',';
-        p += sprintf(p, "gfx%d", archs & 0xffff);
-        gotsome = true;
-    } while ((archs >>= 16));
+        p += sprintf(p, "%s", names[i]);
+    }
+
+    FreeStringList(&name_list);
+    free(names);
 
     // woot
     return true;
@@ -680,8 +761,9 @@ static bool import_cuda_impl(void) {
     case LLAMAFILE_GPU_AMD:
     case LLAMAFILE_GPU_NVIDIA:
         break;
-    default:
+    default: {
         return false;
+    }
     }
     tinylog(__func__, ": initializing gpu module...\n", NULL);
 
@@ -702,8 +784,9 @@ static bool import_cuda_impl(void) {
             break;
         case true:
             needs_rebuild = true;
-            if (!llamafile_extract(srcs[i].zip, src))
+            if (!llamafile_extract(srcs[i].zip, src)) {
                 return false;
+            }
             break;
         default:
             __builtin_unreachable();
@@ -749,16 +832,20 @@ static bool import_cuda_impl(void) {
             }
         }
 
+
         // Check if DSO is already compiled.
         if (!needs_rebuild && !FLAG_recompile) {
             switch (llamafile_is_file_newer_than(src, dso)) {
-            case -1:
+            case -1: {
                 return false;
+            }
             case false:
-                if (link_cuda_dso(dso, library_path))
+                if (link_cuda_dso(dso, library_path)) {
                     return true;
-                else
+                }
+                else {
                     goto TryNvidia;
+                }
             case true:
                 break;
             default:

--- a/llamafile/cuda.c
+++ b/llamafile/cuda.c
@@ -242,30 +242,6 @@ void CopyStringListToStringArray(struct StringList *string_list, char ***string_
     }
 }
 
-void PrintStringList(struct StringList* string_list) {
-    struct StringListEntry* current = string_list->head;
-    printf("[");
-    while (current != NULL) {
-        printf("%s", current->string);
-        if (current != string_list->tail) {
-            printf(",");
-        }
-        current = current->next;
-    }
-    printf("]");
-}
-
-void PrintStringArray(char** string_list, size_t length) {
-    printf("[");
-    for (int i = 0; i < length; ++i) {
-        printf("%s", string_list[i]);
-        if (i != length - 1) {
-            printf(",");
-        }
-    }
-    printf("]");
-}
-
 int RemoveDuplicatesFromStringArray(char **strings, int num_strings) {
     if (num_strings == 1) {
         return 1;
@@ -761,9 +737,8 @@ static bool import_cuda_impl(void) {
     case LLAMAFILE_GPU_AMD:
     case LLAMAFILE_GPU_NVIDIA:
         break;
-    default: {
+    default:
         return false;
-    }
     }
     tinylog(__func__, ": initializing gpu module...\n", NULL);
 
@@ -784,9 +759,8 @@ static bool import_cuda_impl(void) {
             break;
         case true:
             needs_rebuild = true;
-            if (!llamafile_extract(srcs[i].zip, src)) {
+            if (!llamafile_extract(srcs[i].zip, src))
                 return false;
-            }
             break;
         default:
             __builtin_unreachable();
@@ -832,20 +806,16 @@ static bool import_cuda_impl(void) {
             }
         }
 
-
         // Check if DSO is already compiled.
         if (!needs_rebuild && !FLAG_recompile) {
             switch (llamafile_is_file_newer_than(src, dso)) {
-            case -1: {
+            case -1:
                 return false;
-            }
             case false:
-                if (link_cuda_dso(dso, library_path)) {
+                if (link_cuda_dso(dso, library_path))
                     return true;
-                }
-                else {
+                else 
                     goto TryNvidia;
-                }
             case true:
                 break;
             default:

--- a/llamafile/cuda.c
+++ b/llamafile/cuda.c
@@ -243,9 +243,8 @@ void CopyStringListToStringArray(struct StringList *string_list, char ***string_
 }
 
 int RemoveDuplicatesFromStringArray(char **strings, int num_strings) {
-    if (num_strings == 1) {
+    if (num_strings == 1)
         return 1;
-    }
     int tail = 0;
     for (int current = 1; current < num_strings; ++current) {
         if (strcmp(strings[tail], strings[current]) != 0) {
@@ -814,7 +813,7 @@ static bool import_cuda_impl(void) {
             case false:
                 if (link_cuda_dso(dso, library_path))
                     return true;
-                else 
+                else
                     goto TryNvidia;
             case true:
                 break;


### PR DESCRIPTION
This PR changes the the get_amd_offload_arch_flag() function to match all offload-arch types that have alphanumeric names.  For example, on MI250, the offload-arch is gfx90a.  On the MI250a, the function did not match name correctly and passed down "gfx90" into hipcc, and hipcc returned an error.