### PR TITLE
server: multimodal - fix misreported prompt and num prompt tokens

### DIFF
--- a/llama.cpp/server/server.cpp
+++ b/llama.cpp/server/server.cpp
@@ -1371,6 +1371,7 @@ struct llama_server_context
     bool ingest_images(llama_client_slot &slot, int n_batch)
     {
         int image_idx = 0;
+        std::string prompt = "";
 
         while (image_idx < (int) slot.images.size())
         {
@@ -1432,6 +1433,11 @@ struct llama_server_context
                 slot.params.input_suffix : // no more images, then process suffix prompt
                 (json)(slot.images[image_idx].prefix_prompt);
 
+            // rebuild the prompt since it was cleared earlier
+            prompt += img.prefix_prompt;
+            prompt += "[img-" + std::to_string(img.id) + "]";
+            prompt += json_prompt;
+
             std::vector<llama_token> append_tokens = tokenize(json_prompt, false); // has next image
             for (int i = 0; i < (int) append_tokens.size(); ++i)
             {
@@ -1439,6 +1445,13 @@ struct llama_server_context
                 slot.n_past += 1;
             }
         }
+
+        // There is no prompt caching in multimodal currently
+        slot.num_prompt_tokens = slot.n_past;
+        slot.num_prompt_tokens_processed = slot.n_past;
+
+        // prompt for multimodal is set to empty to avoid processing those tokens here
+        slot.prompt = prompt;
 
         return true;
     }


### PR DESCRIPTION
Ported the code from [llama.cpp PR 5896](https://github.com/ggerganov/llama.cpp/pull/5896)

Should address [llama.cpp 5852](https://github.com/ggerganov/llama.cpp/issues/5852) and [llama.cpp 5863](https://github.com/ggerganov/llama.cpp/issues/5863)

To fix, we set the number of tokens processed to it's correct value in ingest_images where the prompt is tokenized for multimodal.

Additionally a fix for the prompt being set to the empty string for multimodal responses. Basically we iteratively rebuild the initial prompt since it was cleared.