### PR TITLE
Update llama.cpp for Meta-LLama-3

### DIFF
--- a/llama.cpp/llama.cpp
+++ b/llama.cpp/llama.cpp
@@ -4315,6 +4315,7 @@ static void llm_load_vocab(
                         (t.first == "<|eot_id|>" ||
                          t.first == "<|im_end|>" ||
                          t.first == "<|end|>" ||
+                         t.first == "<|end_of_text|>" ||
                          t.first == "<end_of_turn>"
                         )
                    ) {


### PR DESCRIPTION
Mine sends <|end_of_text|> at the end of every phrase.
With this I don't see it :D