### PR TITLE
github: delete assignees and about --> description

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug-low.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug-low.yml
@@ -1,8 +1,7 @@
-name: Medium Severity Bug
-about: Used to report medium severity bugs in llamafiles (e.g. Malfunctioning Features but generally still useable)
+name: Low Severity Bugs
+description: Used to report low severity bugs in llamafiles (e.g. cosmetic issues, non critical UI glitches)
 title: "Bug: "
-labels: ["bug", "medium severity"]
-assignees: ''
+labels: ["bug", "low severity"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/02-bug-medium.yml
+++ b/.github/ISSUE_TEMPLATE/02-bug-medium.yml
@@ -1,8 +1,7 @@
-name: High Severity Bug
-about: Used to report high severity bugs in llamafiles (e.g. Malfunctioning features hindering important common workflow)
+name: Medium Severity Bug
+description: Used to report medium severity bugs in llamafiles (e.g. Malfunctioning Features but generally still useable)
 title: "Bug: "
-labels: ["bug", "high severity"]
-assignees: ''
+labels: ["bug", "medium severity"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/03-bug-high.yml
+++ b/.github/ISSUE_TEMPLATE/03-bug-high.yml
@@ -1,8 +1,7 @@
-name: Critical Severity Bug
-about: Used to report critical severity bugs in llamafiles (e.g. Crashing, Corrupted, Dataloss)
+name: High Severity Bug
+description: Used to report high severity bugs in llamafiles (e.g. Malfunctioning features hindering important common workflow)
 title: "Bug: "
-labels: ["bug", "critical severity"]
-assignees: ''
+labels: ["bug", "high severity"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/04-bug-critical.yml
+++ b/.github/ISSUE_TEMPLATE/04-bug-critical.yml
@@ -1,8 +1,7 @@
-name: Low Severity Bugs
-about: Used to report low severity bugs in llamafiles (e.g. cosmetic issues, non critical UI glitches)
+name: Critical Severity Bug
+description: Used to report critical severity bugs in llamafiles (e.g. Crashing, Corrupted, Dataloss)
 title: "Bug: "
-labels: ["bug", "low severity"]
-assignees: ''
+labels: ["bug", "critical severity"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/05-enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/05-enhancement.yml
@@ -1,8 +1,7 @@
 name: Enhancement template
-about: Used to request enhancements for llamafiles
+description: Used to request enhancements for llamafiles
 title: "Feature Request: "
 labels: ["enhancement"]
-assignees: ''
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/06-question.yml
+++ b/.github/ISSUE_TEMPLATE/06-question.yml
@@ -1,8 +1,7 @@
 name: Question template
-about: Used to ask questions about llamafiles
+description: Used to ask questions about llamafiles
 title: "Question: "
 labels: ["question"]
-assignees: ''
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
Github said that there are some problems with the issue template

assignees must be of type String or Array. [Learn more about error 1.](https://docs.github.com/communities/using-templates-to-encourage-useful-issues-and-pull-requests/common-validation-errors-when-creating-issue-forms#key-must-be-a-string)

about is not a permitted key. [Learn more about error 2.](https://docs.github.com/communities/using-templates-to-encourage-useful-issues-and-pull-requests/common-validation-errors-when-creating-issue-forms#input-is-not-a-permitted-key)

Double checked https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms