### PR TITLE
github: add docker based ci github actions

### DIFF
--- a/.devops/ci.Dockerfile
+++ b/.devops/ci.Dockerfile
@@ -1,0 +1,46 @@
+
+###############################################################################
+FROM alpine as build
+
+RUN apk update && \
+    apk add build-base git
+
+WORKDIR /build
+COPY . .
+RUN make -j $(nproc)
+
+###############################################################################
+FROM alpine as package
+
+WORKDIR /package
+
+COPY --from=build /build/o/llama.cpp/main/main              ./llamafile
+COPY --from=build /build/o/llamafile/zipalign               ./zipalign
+COPY --from=build /build/models/TinyLLama-v0.1-5M-F16.gguf  ./model.gguf
+
+RUN echo "-m" > .args
+RUN echo "model.gguf" >> .args
+RUN ./zipalign -j0 llamafile model.gguf .args
+
+RUN chmod +x ./llamafile
+
+###############################################################################
+FROM alpine as final
+
+WORKDIR /usr/src/app
+
+COPY --from=package /package/llamafile ./llamafile
+
+RUN ./llamafile -e -p '## Famous Speech\n\nFour score and seven' -n 50 -ngl 0
+
+ENTRYPOINT ["/bin/sh", "/usr/src/app/llamafile"]
+CMD ["--cli", "-p", "hello world the gruff man said"]
+
+## Just running test?
+# docker build -f .devops/ci.Dockerfile -t llamafile_ci .
+# docker run llamafile_ci
+
+## Get the binary?
+# docker build -f .devops/ci.Dockerfile -t llamafile_ci .
+# docker create --name llamafile_ci_container llamafile_ci
+# docker cp llamafile_ci_container:/usr/src/app/llamafile test.llamafile

--- a/.devops/ci.Dockerfile
+++ b/.devops/ci.Dockerfile
@@ -3,7 +3,7 @@
 FROM alpine as build
 
 RUN apk update && \
-    apk add build-base git
+    apk add make
 
 WORKDIR /build
 COPY . .

--- a/.devops/ci.Dockerfile
+++ b/.devops/ci.Dockerfile
@@ -7,7 +7,8 @@ RUN apk update && \
 
 WORKDIR /build
 COPY . .
-RUN make -j $(nproc)
+
+RUN make
 
 ###############################################################################
 FROM alpine as package

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+on:
+  push:
+    branches: [ master, main, fix ]
+  pull_request:
+    branches: [ master, main, fix ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Cache Docker layers
+      uses: actions/cache@v3
+      with:
+        path: /tmp/.buildx-cache
+        key: ${{ runner.os }}-buildx-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-buildx-
+
+    - name: Build Docker image
+      run: |
+        docker build -f .devops/ci.Dockerfile -t llamafile_ci .
+
+    - name: Run Docker container
+      run: |
+        docker run llamafile_ci

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # llamafile
 
+[![ci status](https://github.com/Mozilla-Ocho/llamafile/actions/workflows/ci.yml/badge.svg)](https://github.com/Mozilla-Ocho/llamafile/actions/workflows/ci.yml)
+
 <img src="llamafile/llamafile-640x640.png" width="320" height="320"
      alt="[line drawing of llama animal head in front of slightly open manilla folder filled with files]">
 


### PR DESCRIPTION
Similar to https://github.com/Mozilla-Ocho/llamafile/pull/454 but using docker container. This also means that sanity checking that the build process works on desktop is easier (e.g. pre-commit hooks)