### PR TITLE
Fix GPU Layer Limitation in llamafile

### DIFF
--- a/llama.cpp/llama.cpp
+++ b/llama.cpp/llama.cpp
@@ -5577,7 +5577,7 @@ static bool llm_load_tensors(
 
     auto & hparams = model.hparams;
 
-    n_gpu_layers = std::min(n_gpu_layers, (int)hparams.n_layer); // [jart]
+    // n_gpu_layers = std::min(n_gpu_layers, (int)hparams.n_layer); // [jart]
     n_gpu_layers = std::max(n_gpu_layers, 0); // [jart]
 
     model.split_mode   = split_mode;


### PR DESCRIPTION
#533 
In the current implementation, the line `n_gpu_layers = std::min(n_gpu_layers, (int)hparams.n_layer);` restricts the minimum value of `n_gpu_layers`. However, in the llama.cpp project, within the `static void llm_load_hparams` function, `hparams.n_layer` is derived from `ml.get_key(LLM_KV_BLOCK_COUNT, hparams.n_layer);`, which only accounts for layers that require key-value (KV) attention and does not include other potential layers, such as output layers.

This restriction might lead to performance issues, as observed in the token generation speed and GPU utilization.

By either commenting out this line or adjusting it to `hparams.n_layer + 10`, the issue can be mitigated, ensuring all necessary layers are properly offloaded to the GPU, improving overall performance.