### PR TITLE
whisperfile server: convert files without ffmpeg

### DIFF
--- a/whisper.cpp/common.cpp
+++ b/whisper.cpp/common.cpp
@@ -37,21 +37,6 @@ static void on_exit(void) {
     }
 }
 
-bool is_wav_buffer(const std::string buf) {
-    // RIFF ref: https://en.wikipedia.org/wiki/Resource_Interchange_File_Format
-    // WAV ref: https://www.mmsp.ece.mcgill.ca/Documents/AudioFormats/WAVE/WAVE.html
-    if (buf.size() < 12 || buf.substr(0, 4) != "RIFF" || buf.substr(8, 4) != "WAVE") {
-        return false;
-    }
-
-    uint32_t chunk_size = *reinterpret_cast<const uint32_t*>(buf.data() + 4);
-    if (chunk_size + 8 != buf.size()) {
-        return false;
-    }
-
-    return true;
-}
-
 static ma_result perform_audio_conversion(ma_decoder* pDecoder, ma_encoder* pEncoder) {
     ma_result rc = MA_SUCCESS;
     for (;;) {
@@ -172,12 +157,6 @@ TryAgain:
         }
 
         fprintf(stderr, "%s: read %zu bytes from stdin\n", __func__, wav_data.size());
-    }
-    else if (is_wav_buffer(fname)) {
-        if (drwav_init_memory(&wav, fname.c_str(), fname.size(), nullptr) == false) {
-            fprintf(stderr, "error: failed to open WAV file from fname buffer\n");
-            return false;
-        }
     }
     else if (drwav_init_file(&wav, fname.c_str(), nullptr) == false) {
         tinylogf("%s: converting to wav...\n", fname.c_str());


### PR DESCRIPTION
This PR allows the `whisperfile` server to convert `.wav`, `.mp3`, `.flac`, and `.ogg` into the appropriate .wav file for whisper (16-bit 16000Hz) without any dependency on ffmpeg.

The ffmpeg support still remains under the `--convert` flag.

The main change here is giving `read_wav` a file instead of a buffer. Before it was given a buffer when run through the server, and a filename when run through the cli. Now it is unified to always use a filename.

In addition `is_wav_buffer` was removed, as the codepath is dead with the changes to use a filename throughout. This function was always expecting a buffer, but was receiving both filenames and buffers.