### PR TITLE
Update WSL troubleshooting in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,7 +341,14 @@ WantedBy=multi-user.target
 
 Put that in `/etc/systemd/system/cosmo-binfmt.service`.
 
-Then run `sudo systemctl enable cosmo-binfmt`.
+Ensure that the APE loader is installed to `/usr/bin/ape`:
+
+```sh
+sudo wget -O /usr/bin/ape https://cosmo.zip/pub/cosmos/bin/ape-$(uname -m).elf
+sudo chmod +x /usr/bin/ape
+```
+
+Then run `sudo systemctl enable --now cosmo-binfmt`.
 
 Another thing that's helped WSL users who experience issues, is to
 disable the WIN32 interop feature:


### PR DESCRIPTION
This instructs WSL users they need to install `/usr/bin/ape` in order to use `cosmo-binfmt.service`.

I'm not an expert on αcτµαlly pδrταblε εxεcµταblε's or binfmt_misc, but I needed to install the APE loader to `/usr/bin/ape` as suggested in the Linux troubleshooting section in order to get `cosmo-binfmt.service` to work on my WSL 2 Ubuntu installation.

I also added the `--now` flag to the `systemctl enable` command for convenience.

The Linux troubleshooting section adds entries with both `MZqFpD` and `jartsr` as magic strings, so it's tempting to do the same in  `cosmo-binfmt.service` for consistency, but I didn't need the `jartsr` entry for the `Llama-3.2-3B-Instruct.F16.llamafile` I tested this with, so I'm guessing that's only necessary for legacy executables and left it out.

@jart Does this change make sense to you? I could submit a PR to update the https://github.com/jart/cosmopolitan README to suggest adding the `cosmo-binfmt.service` too. It's nice to be able to support both APE and Windows binaries on WSL.