### PR TITLE
add llama_matmul_demo2_bf16.c with other parallelize experiment

### DIFF
--- a/llamafile/BUILD.mk
+++ b/llamafile/BUILD.mk
@@ -124,6 +124,7 @@ o/$(MODE)/llamafile/llama_matmul_avx2_bf16.o: private TARGET_ARCH += -Xx86_64-ma
 o/$(MODE)/llamafile/llama_matmul_avx512_bf16.o: private TARGET_ARCH += -Xx86_64-march=znver4 -O3
 o/$(MODE)/llamafile/llama_matmul_demo_fp16.o: private TARGET_ARCH += -Xx86_64-march=znver4 -O3 -fopenmp
 o/$(MODE)/llamafile/llama_matmul_demo_bf16.o: private TARGET_ARCH += -Xx86_64-march=znver4 -O3 -fopenmp
+o/$(MODE)/llamafile/llama_matmul_demo2_bf16.o: private TARGET_ARCH += -Xx86_64-march=znver4 -O3 -fopenmp
 
 o/$(MODE)/llamafile/sgemm.o: private CXXFLAGS += -Os
 
@@ -225,3 +226,7 @@ o/$(MODE)/llamafile/check:					\
 		o/$(MODE)/llamafile/tinyblas_test.runs		\
 		o/$(MODE)/llamafile/llama_matmul_demo_fp16	\
 		o/$(MODE)/llamafile/llama_matmul_demo_bf16	\
+
+
+# o/$(MODE)/llamafile/llama_matmul_demo2_bf16	\
+

--- a/llamafile/llama_matmul_demo_fp16.c
+++ b/llamafile/llama_matmul_demo_fp16.c
@@ -5,8 +5,8 @@
 
 // run me:
 //
-//     make -j o//llamafile/llama_matmul_demo
-//     o//llamafile/llama_matmul_demo
+//     make -j o//llamafile/llama_matmul_demo_fp16
+//     o//llamafile/llama_matmul_demo_fp16
 //
 
 #include <immintrin.h>


### PR DESCRIPTION
You was not too far from good speed. 

But if you look at BLIS paper, bloc_A need to be keep in L2 cache, on x86 CPU (zen ...) there is 1 L2 cache per core, so each bloc compute on a core need is own bloc_A.

With this demo I have speed up of 1.77 on my zen4 8 core ( AMD Ryzen 9 7940HS )

Note: there is more to do for best perf:
  - B is broadcast so it is not needed to transpose it I think. 
  - bloc_B need to be keep in L3 cache, it is the case on my 8 core zen4, but not on the 16+ core zen4 and zen2 (1 L3 for 4 core...) for best we can have bloc_B per L3 cache
  - Next, if N in big enough we can parallelize on first loop 
```cpp
for (int j = ith * NC; j < N; j += NT) { 
    [...]
}
```
