### PR TITLE
Support for configurable URL prefix when running in server mode

### DIFF
--- a/llama.cpp/common.cpp
+++ b/llama.cpp/common.cpp
@@ -1078,6 +1078,11 @@ bool gpt_params_find_arg(int argc, char ** argv, const std::string & arg, gpt_pa
         params.public_path = argv[i];
         return true;
     }
+    if (arg == "--url-prefix") {
+        CHECK_ARG
+        params.url_prefix = argv[i];
+        return true;
+    }
     if (arg == "--api-key") {
         CHECK_ARG
         params.api_keys.push_back(argv[i]);
@@ -1605,6 +1610,7 @@ void gpt_params_print_usage(int /*argc*/, char ** argv, const gpt_params & param
     options.push_back({ "server",      "       --host HOST",            "ip address to listen (default: %s)", params.hostname.c_str() });
     options.push_back({ "server",      "       --port PORT",            "port to listen (default: %d)", params.port });
     options.push_back({ "server",      "       --path PATH",            "path to serve static files from (default: %s)", params.public_path.c_str() });
+    options.push_back({ "server",      "       --url-prefix PREFIX",    "Specify a URL prefix (subdirectory) under which the API will be served, e.g. /llamafile (default: %s)", params.url_prefix.c_str() });
     options.push_back({ "server",      "       --embedding(s)",         "enable embedding endpoint (default: %s)", params.embedding ? "enabled" : "disabled" });
     options.push_back({ "server",      "       --api-key KEY",          "API key to use for authentication (default: none)" });
     options.push_back({ "server",      "       --api-key-file FNAME",   "path to file containing API keys (default: none)" });

--- a/llama.cpp/common.h
+++ b/llama.cpp/common.h
@@ -214,6 +214,7 @@ struct gpt_params {
 
     std::string hostname      = "127.0.0.1";
     std::string public_path   = "";
+    std::string url_prefix    = "";
     std::string chat_template = "";
     std::string system_prompt = "";
     bool enable_chat_template = true;

--- a/llama.cpp/main/main.1
+++ b/llama.cpp/main/main.1
@@ -759,6 +759,11 @@ Path from which to serve static files.
 .Pp
 Default:
 .Pa /zip/llama.cpp/server/public
+.It Fl Fl url-prefix Ar PREFIX
+Specify a URL prefix (subdirectory) under which the API will be served, e.g. /llamafile
+.Pp
+Default:
+.Pa /
 .It Fl Fl nobrowser
 Do not attempt to open a web browser tab at startup.
 .It Fl gan Ar N , Fl Fl grp-attn-n Ar N

--- a/llama.cpp/main/main.1.asc
+++ b/llama.cpp/main/main.1.asc
@@ -735,6 +735,11 @@
 
                Default: [4m/zip/llama.cpp/server/public[0m
 
+       [1m--url-prefix [4m[22mPREFIX[0m
+               Specify a URL prefix (subdirectory) under which the API will be served, e.g. /llamafile.
+
+               Default: [4m/[0m
+
        [1m--nobrowser[0m
                Do not attempt to open a web browser tab at startup.
 

--- a/llama.cpp/server/public/completion.js
+++ b/llama.cpp/server/public/completion.js
@@ -21,14 +21,14 @@ let generation_settings = null;
 //
 export async function* llama(prompt, params = {}, config = {}) {
   let controller = config.controller;
-
+  const url_prefix = config.url_prefix || "";
   if (!controller) {
     controller = new AbortController();
   }
 
   const completionParams = { ...paramDefaults, ...params, prompt };
 
-  const response = await fetch("/completion", {
+  const response = await fetch(`${url_prefix}/completion`, {
     method: 'POST',
     body: JSON.stringify(completionParams),
     headers: {
@@ -193,9 +193,10 @@ export const llamaComplete = async (params, controller, callback) => {
 }
 
 // Get the model info from the server. This is useful for getting the context window and so on.
-export const llamaModelInfo = async () => {
+export const llamaModelInfo = async (config = {}) => {
   if (!generation_settings) {
-    const props = await fetch("/props").then(r => r.json());
+    const url_prefix = config.url_prefix || "";
+    const props = await fetch(`${url_prefix}/props`).then(r => r.json());
     generation_settings = props.default_generation_settings;
   }
   return generation_settings;

--- a/llama.cpp/server/public/index.html
+++ b/llama.cpp/server/public/index.html
@@ -213,10 +213,10 @@
   <script type="module">
     import {
       html, h, signal, effect, computed, render, useSignal, useEffect, useRef, Component
-    } from '/index.js';
+    } from './index.js';
 
-    import { llama } from '/completion.js';
-    import { SchemaConverter } from '/json-schema-to-grammar.mjs';
+    import { llama } from './completion.js';
+    import { SchemaConverter } from './json-schema-to-grammar.mjs';
     let selected_image = false;
     var slot_id = -1;
 
@@ -419,7 +419,7 @@
         throw new Error("already running");
       }
       controller.value = new AbortController();
-      for await (const chunk of llama(prompt, llamaParams, { controller: controller.value })) {
+      for await (const chunk of llama(prompt, llamaParams, { controller: controller.value, url_prefix: document.baseURI.replace(/\/+$/, '') })) {
         const data = chunk.data;
 
         if (data.stop) {

--- a/llama.cpp/server/server.cpp
+++ b/llama.cpp/server/server.cpp
@@ -3132,8 +3132,8 @@ int server_cli(int argc, char **argv)
     const char *connect_host;
     if (sparams.hostname != "0.0.0.0") {
         connect_host = sparams.hostname.c_str();
-        LOG_TEE("\nllama server listening at http://%s:%d\n\n",
-                sparams.hostname.c_str(), sparams.port);
+        LOG_TEE("\nllama server listening at http://%s:%d%s\n\n",
+                sparams.hostname.c_str(), sparams.port, sparams.url_prefix.c_str());
     } else {
         struct ifaddrs *ifaddrs;
         connect_host = "127.0.0.1";
@@ -3142,23 +3142,25 @@ int server_cli(int argc, char **argv)
             for (struct ifaddrs *ifa = ifaddrs; ifa; ifa = ifa->ifa_next) {
                 char buf[128];
                 if (!(ifa->ifa_flags & IFF_UP)) continue;
-                LOG_TEE("llama server listening at http://%s%s%s:%d\n",
+                LOG_TEE("llama server listening at http://%s%s%s:%d%s\n",
                         ifa->ifa_addr->sa_family == AF_INET6 ? "[" : "",
                         sockaddr2str(ifa->ifa_addr, buf, sizeof(buf)),
                         ifa->ifa_addr->sa_family == AF_INET6 ? "]" : "",
-                        sparams.port);
+                        sparams.port,
+                        sparams.url_prefix.c_str());
             }
             LOG_TEE("\n");
         } else {
             perror("getifaddrs");
-            LOG_TEE("\nllama server listening at http://%s:%d\n\n",
-                    sparams.hostname.c_str(), sparams.port);
+            LOG_TEE("\nllama server listening at http://%s:%d%s\n\n",
+                    sparams.hostname.c_str(), sparams.port, sparams.url_prefix.c_str());
         }
     }
 
     std::unordered_map<std::string, std::string> log_data;
     log_data["hostname"] = sparams.hostname;
     log_data["port"] = std::to_string(sparams.port);
+    log_data["url_prefix"] = sparams.url_prefix;
 
     if (sparams.api_keys.size() == 1) {
         log_data["api_key"] = "api_key: ****" + sparams.api_keys[0].substr(sparams.api_keys[0].length() - 4);


### PR DESCRIPTION
Added support for new commandline parameter --url-prefix that sets the URL prefix (subdirectory) under which the API will be served when llamafile is running in server mode, e.g.

`llamafile --server --url-prefix /llamafile -m mymodel.gguf`

Makes it much easier to run llamafile behind a reverse proxy.