### PR TITLE
add stable-diffusion.cpp to install target (fix #580)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,7 @@ install:	llamafile/zipalign.1					\
 		o/$(MODE)/llama.cpp/llama-bench/llama-bench		\
 		o/$(MODE)/llama.cpp/perplexity/perplexity		\
 		o/$(MODE)/llama.cpp/llava/llava-quantize		\
+		o/$(MODE)/stable-diffusion.cpp/main			\
 		o/$(MODE)/whisper.cpp/main				\
 		o/$(MODE)/llamafile/server/main
 	mkdir -p $(PREFIX)/bin


### PR DESCRIPTION
The "install" target of the Makefile was missing stable-diffusion.cpp so on a clean checkout "make install" fails like reported in #580. With this patch clean checkouts can do "make install" without error and have a working sdfile executable.