### PR TITLE
URL constructor to get a clean url_prefix (fix #640)

### DIFF
--- a/llama.cpp/server/public/index.html
+++ b/llama.cpp/server/public/index.html
@@ -419,7 +419,7 @@
         throw new Error("already running");
       }
       controller.value = new AbortController();
-      for await (const chunk of llama(prompt, llamaParams, { controller: controller.value, url_prefix: document.baseURI.replace(/\/+$/, '') })) {
+      for await (const chunk of llama(prompt, llamaParams, { controller: controller.value, url_prefix: new URL('.', document.baseURI).origin })) {
         const data = chunk.data;
 
         if (data.stop) {


### PR DESCRIPTION
Replace the too simple regexp by URL constructor to really get clean url_prefix