### PR TITLE
Update Makefile: Fix PHONY from check to cosmocc and cosmocc-ci respectively

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,10 +74,10 @@ install:	llamafile/zipalign.1					\
 .PHONY: check
 check: o/$(MODE)/llamafile/check
 
-.PHONY: check
+.PHONY: cosmocc
 cosmocc: $(COSMOCC) # cosmocc toolchain setup
 
-.PHONY: check
+.PHONY: cosmocc-ci
 cosmocc-ci: $(COSMOCC) $(PREFIX)/bin/ape # cosmocc toolchain setup in ci context
 
 include build/deps.mk


### PR DESCRIPTION
Low urgency PR

Appears to be a typo in the makefile for the .PHONY keyword.

This mostly will only be an issue if you have a file named `cosmocc` or `cosmocc-ci`

But for consistency reason we may want to fix this anyway.