### PR TITLE
Updated README to reflect WSL 2 command for Windows 11

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,6 +366,13 @@ disable the WIN32 interop feature:
 sudo sh -c "echo -1 > /proc/sys/fs/binfmt_misc/WSLInterop"
 ```
 
+In Windows 11 with WSL 2 the location of the interop flag has changed, as such
+the following command should be used instead:
+
+```sh
+sudo sh -c "echo -1 > /proc/sys/fs/binfmt_misc/WSLInterop-late"
+```
+
 In the instance of getting a `Permission Denied` on disabling interop
 through CLI, it can be permanently disabled by adding the following in
 `/etc/wsl.conf`

--- a/README.md
+++ b/README.md
@@ -367,7 +367,7 @@ sudo sh -c "echo -1 > /proc/sys/fs/binfmt_misc/WSLInterop"
 ```
 
 In Windows 11 with WSL 2 the location of the interop flag has changed, as such
-the following command be required instead/addition:
+the following command be required instead/additionally:
 
 ```sh
 sudo sh -c "echo -1 > /proc/sys/fs/binfmt_misc/WSLInterop-late"

--- a/README.md
+++ b/README.md
@@ -367,7 +367,7 @@ sudo sh -c "echo -1 > /proc/sys/fs/binfmt_misc/WSLInterop"
 ```
 
 In Windows 11 with WSL 2 the location of the interop flag has changed, as such
-the following command should be used instead:
+the following command be required instead/addition:
 
 ```sh
 sudo sh -c "echo -1 > /proc/sys/fs/binfmt_misc/WSLInterop-late"


### PR DESCRIPTION
After spending a lot of time trawling around forums and issues, trying various commands, I stumbled upon [this comment](https://github.com/Mozilla-Ocho/llamafile/issues/275#issuecomment-2123026156) in an [issue](https://github.com/Mozilla-Ocho/llamafile/issues/275) which solves the problem for me (and now hopefully others running Windows 11 with WSL 2).

TL;DR: 

```bash
sudo sh -c "echo -1 > /proc/sys/fs/binfmt_misc/WSLInterop-late"
```

Please let me know if there's any changes you'd like, but it would be good to see this in the README as it can hopefully save someone else a lot of internet searching. 😄 