### PR TITLE
Avoid streaming incomplete UTF-8 characters

### DIFF
--- a/llamafile/server/utf.cpp
+++ b/llamafile/server/utf.cpp
@@ -1,0 +1,49 @@
+// -*- mode:c++;indent-tabs-mode:nil;c-basic-offset:4;coding:utf-8 -*-
+// vi: set et ft=cpp ts=4 sts=4 sw=4 fenc=utf-8 :vi
+//
+// Copyright 2024 Mozilla Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "utils.h"
+#include <string>
+
+namespace lf {
+namespace server {
+
+bool ends_with_incomplete_utf8(const std::string& str) {
+    for (unsigned i = 1; i <= 4 && i <= str.size(); ++i) {
+        unsigned char c = str[str.size() - i];
+        if ((c & 0xC0) == 0x80) {
+            // continuation byte: 10xxxxxx
+            continue;
+        }
+        if ((c & 0xE0) == 0xC0) {
+            // 2-byte character: 110xxxxx ...
+            return i < 2;
+        } else if ((c & 0xF0) == 0xE0) {
+            // 3-byte character: 1110xxxx ...
+            return i < 3;
+        } else if ((c & 0xF8) == 0xF0) {
+            // 4-byte character: 11110xxx ...
+            return i < 4;
+        }
+        // else 1-byte character or invalid byte
+        break; // Found a valid starting byte, no need to check further.
+    }
+
+    return false; // Did not find an incomplete character
+}
+
+} // namespace server
+} // namespace lf

--- a/llamafile/server/utils.h
+++ b/llamafile/server/utils.h
@@ -50,5 +50,8 @@ remove_old_image_atoms(const std::vector<Atom>&);
 int
 count_tokens(const std::vector<Atom>&);
 
+bool
+ends_with_incomplete_utf8(const std::string& str);
+
 } // namespace server
 } // namespace lf


### PR DESCRIPTION
Some characters, like the chinese fù is sometimes returned as two tokens, as "\u00e8\u00b5" and "\u008b" in this case.

This is also depends on the model, but when it happens, for example with DeepSeek R1, we have to wait for the character to be complete and send it only then.

This resolves #722 and #646