### PR TITLE
Preserve URL path when building relative URLs in JS

### DIFF
--- a/llama.cpp/server/public/completion.js
+++ b/llama.cpp/server/public/completion.js
@@ -7,6 +7,20 @@ const paramDefaults = {
 
 let generation_settings = null;
 
+// Returns a new URL that starts with `urlPrefix` and ends with `path`. The
+// `path` must not begin with a slash. This is more robust than `new URL(path,
+// urlPrefix)` because it preserves the prefix's entire path, even when the
+// prefix has no trailing slash.
+function buildUrl(urlPrefix, path) {
+  if (path.startsWith('/')) {
+    throw new Error("path must not have a leading slash");
+  }
+  const base = new URL(urlPrefix);
+  if (!base.pathname.endsWith('/')) {
+    base.pathname += '/';
+  }
+  return new URL(path, base);
+}
 
 // Completes the prompt as a generator. Recommended for most use cases.
 //
@@ -28,7 +42,7 @@ export async function* llama(prompt, params = {}, config = {}) {
 
   const completionParams = { ...paramDefaults, ...params, prompt };
 
-  const response = await fetch(`${url_prefix}/completion`, {
+  const response = await fetch(buildUrl(url_prefix, 'completion'), {
     method: 'POST',
     body: JSON.stringify(completionParams),
     headers: {
@@ -196,7 +210,7 @@ export const llamaComplete = async (params, controller, callback) => {
 export const llamaModelInfo = async (config = {}) => {
   if (!generation_settings) {
     const url_prefix = config.url_prefix || "";
-    const props = await fetch(`${url_prefix}/props`).then(r => r.json());
+    const props = await fetch(buildUrl(url_prefix, 'props')).then(r => r.json());
     generation_settings = props.default_generation_settings;
   }
   return generation_settings;

--- a/llama.cpp/server/public/index.html
+++ b/llama.cpp/server/public/index.html
@@ -419,7 +419,8 @@
         throw new Error("already running");
       }
       controller.value = new AbortController();
-      for await (const chunk of llama(prompt, llamaParams, { controller: controller.value, url_prefix: new URL('.', document.baseURI).origin })) {
+
+      for await (const chunk of llama(prompt, llamaParams, { controller: controller.value, url_prefix: document.baseURI })) {
         const data = chunk.data;
 
         if (data.stop) {


### PR DESCRIPTION
It's necessary to preserve the path because the server might be hosted under a subdirectory, specified by `--url-prefix`.

Fixes #732