### PR TITLE
Fixed parsing code for --ip-header commandline option

### DIFF
--- a/llamafile/server/client.cpp
+++ b/llamafile/server/client.cpp
@@ -213,12 +213,15 @@ Client::transport()
         if (is_loopback_ip(client_ip_) || client_ip_trusted_) {
             std::string_view ip_header = get_header(FLAG_ip_header);
             if (!ip_header.empty()) {
-                long ip;
-                if ((ip = parse_ip(ip_header)) == -1) {
+                // Extract the first IP (before any commas)
+                size_t comma = ip_header.find(',');
+                std::string_view first_ip = ip_header.substr(0, comma);
+                long ip = parse_ip(first_ip);
+                if (ip != -1) {
                     effective_ip_ = ip;
                     effective_ip_trusted_ = is_trusted_ip(ip);
                 } else {
-                    SLOG("client's --ip-header wasn't a single ipv4 address");
+                    SLOG("client's --ip-header didn't start with a valid IPv4 address: ", ip_header);
                     effective_ip_trusted_ = false;
                 }
             }


### PR DESCRIPTION
Fixed incorrect parsing of the HTTP X-Forwarded-For header when the --ip-header commandline option is used in server mode.

We should not assume that the X-Forwarded-For header (and synonyms) contain only the client's IP address. The header can contain a comma-separated list that also includes proxies in the chain.

See the following:

https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-Forwarded-For