### PR TITLE
Fix Server v2 production issues (#767, #783, #787)

### DIFF
--- a/llama.cpp/main/main.cpp
+++ b/llama.cpp/main/main.cpp
@@ -199,6 +199,9 @@ int main(int argc, char ** argv) {
         __builtin_unreachable();
     }
 
+    // Load .args file BEFORE determining program type
+    argc = cosmo_args("/zip/.args", &argv);
+    
     enum Program prog = determine_program(argv);
     if (prog == LLAMAFILER)
         return lf::server::main(argc, argv);
@@ -207,7 +210,6 @@ int main(int argc, char ** argv) {
     mallopt(M_MMAP_THRESHOLD, 16 * 1024 * 1024);
     mallopt(M_TRIM_THRESHOLD, 128 * 1024 * 1024);
     ShowCrashReports();
-    argc = cosmo_args("/zip/.args", &argv);
 
     if (prog == SERVER)
         return server_cli(argc, argv);

--- a/llamafile/server/worker.cpp
+++ b/llamafile/server/worker.cpp
@@ -56,13 +56,16 @@ Worker::begin()
         tokens = tokenbucket_acquire(client_.client_ip_);
     server_->lock();
     dll_remove(&server_->idle_workers, &elem_);
-    if (dll_is_empty(server_->idle_workers)) {
-        Dll* slowbro;
-        if ((slowbro = dll_last(server_->active_workers))) {
-            SLOG("all threads active! dropping oldest client");
-            WORKER(slowbro)->kill();
-        }
-    }
+    // Remove aggressive client cancellation - let TCP backlog handle overflow
+    // The kernel's listen backlog will naturally queue incoming connections
+    // until a worker becomes available, providing better user experience
+    // if (dll_is_empty(server_->idle_workers)) {
+    //     Dll* slowbro;
+    //     if ((slowbro = dll_last(server_->active_workers))) {
+    //         SLOG("all threads active! dropping oldest client");
+    //         WORKER(slowbro)->kill();
+    //     }
+    // }
     working_ = true;
     if (tokens > FLAG_token_burst) {
         dll_make_last(&server_->active_workers, &elem_);


### PR DESCRIPTION
This PR fixes three critical issues preventing Server v2 from being used in production:

1. **URL prefix normalization** - Now handles `--url-prefix //path` correctly like the old server
2. **Args file loading** - Fixed `.args` being loaded too late 
3. **Connection stability** - Removed aggressive client dropping, fixed partial writes, increased buffer size

The changes are minimal (~60 lines) and follow patterns from the existing server implementation.

Fixes #767, #783, #787