### PR TITLE
Fix .args loading order for program mode detection

### DIFF
--- a/llama.cpp/main/main.cpp
+++ b/llama.cpp/main/main.cpp
@@ -199,15 +199,15 @@ int main(int argc, char ** argv) {
         __builtin_unreachable();
     }
 
-    enum Program prog = determine_program(argv);
-    if (prog == LLAMAFILER)
-        return lf::server::main(argc, argv);
-
     mallopt(M_GRANULARITY, 2 * 1024 * 1024);
     mallopt(M_MMAP_THRESHOLD, 16 * 1024 * 1024);
     mallopt(M_TRIM_THRESHOLD, 128 * 1024 * 1024);
     ShowCrashReports();
     argc = cosmo_args("/zip/.args", &argv);
+
+    enum Program prog = determine_program(argv);
+    if (prog == LLAMAFILER)
+        return lf::server::run(argc, argv, true);
 
     if (prog == SERVER)
         return server_cli(argc, argv);

--- a/llamafile/server/main.cpp
+++ b/llamafile/server/main.cpp
@@ -20,5 +20,5 @@
 int
 main(int argc, char* argv[])
 {
-    return lf::server::main(argc, argv);
+    return lf::server::run(argc, argv, false);
 }

--- a/llamafile/server/prog.cpp
+++ b/llamafile/server/prog.cpp
@@ -35,7 +35,7 @@ namespace server {
 Server* g_server;
 
 int
-main(int argc, char* argv[])
+run(int argc, char* argv[], bool args_already_loaded)
 {
     llamafile_check_cpu();
     signal(SIGPIPE, SIG_IGN);
@@ -56,7 +56,8 @@ main(int argc, char* argv[])
     }
 
     // get config
-    argc = cosmo_args("/zip/.args", &argv);
+    if (!args_already_loaded)
+        argc = cosmo_args("/zip/.args", &argv);
     llamafile_get_flags(argc, argv);
 
     // initialize subsystems

--- a/llamafile/server/prog.h
+++ b/llamafile/server/prog.h
@@ -4,7 +4,7 @@ namespace lf {
 namespace server {
 
 int
-main(int, char**);
+run(int, char**, bool);
 
 } // namespace server
 } // namespace lf


### PR DESCRIPTION
**Note: This PR targets release v0.9.3 (commit ff0c02e) to make it easy for users relying on the last stable release to apply this fix to their local builds. Upstream main has since restructured to use submodules and patches.**

## Summary
- Move `cosmo_args()` before `determine_program()` so embedded `.args` flags like `--server --v2` are visible when determining program mode
- Rename `lf::server::main()` to `lf::server::run()` with `args_already_loaded` parameter to avoid double-loading `.args`

## Problem
When a llamafile has an embedded `.args` file containing `--server --v2`, the `determine_program()` call happens BEFORE `cosmo_args()` loads the embedded args. These flags are not seen, so the program falls through to chatbot mode instead of launching llamafiler.

## Issue with PR #788
PR #788 correctly identifies this bug and moves `cosmo_args()` before `determine_program()`. However, it introduces a double-loading issue: when the program dispatches to llamafiler mode, `lf::server::main()` in `prog.cpp` calls `cosmo_args()` again. This causes `.args` to be loaded twice, which is problematic for accumulator flags like `--header` that append values rather than overwrite them.

## Solution
This PR:
1. Moves `cosmo_args()` call before `determine_program()` in `llama.cpp/main/main.cpp`
2. Renames `lf::server::main()` to `lf::server::run()` with an `args_already_loaded` parameter
3. The dispatcher passes `true` to skip the redundant `.args` load
4. Standalone `llamafiler` binary passes `false` to load its own args

This provides the same fix as PR #788 while avoiding the double-loading issue.

## Test plan
- [ ] Build llamafile
- [ ] Embed a `.args` file containing `--server --v2` in a llamafile using zipalign
- [ ] Run the llamafile and verify it launches llamafiler instead of chatbot
- [ ] Verify standalone `llamafiler` binary still works correctly

Enhances the `.args` timing fix from PR #788.