### PR TITLE
feat(update-llama-cpp): Create issue to be assigned to copilot.

### DIFF
--- a/.github/workflows/update-llama-cpp.yml
+++ b/.github/workflows/update-llama-cpp.yml
@@ -58,7 +58,7 @@ jobs:
         # Create an issue and assign it to Copilot
         gh issue create \
           --title "Update llama.cpp submodule to ${{ steps.check.outputs.latest_short }}" \
-          --assignee "copilot" \
+          --assignee "daavoo" \
           --body "A new version of llama.cpp is available. Please update the submodule from \`${{ steps.check.outputs.current_short }}\` to \`${{ steps.check.outputs.latest_short }}\` and make necessary adjustments.
 
         ## Step 1: Update the submodule


### PR DESCRIPTION
Trying to automate the manual steps described in https://github.com/mozilla-ai/llamafile/pull/847.

I think the simplest approach is to create an issue (we can iterate on the description) that can be assigned to copilot in order to perform the submodule update + manual verification steps.

Example PR generated by copilot:

https://github.com/mozilla-ai/llamafile/pull/855