### PR TITLE
Fix whisperfile documentation link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ framework that collapses all the complexity of LLMs down to
 a single-file executable (called a "llamafile") that runs
 locally on most operating systems and CPU archiectures, with no installation.
 
-llamafile also includes **[whisperfile](whisperfile/index.md)**, a single-file speech-to-text tool built on [whisper.cpp](https://github.com/ggerganov/whisper.cpp) and the same Cosmopolitan packaging. It supports transcription and translation of audio files across all the same platforms, with no installation required.
+llamafile also includes **[whisperfile](docs/whisperfile/index.md)**, a single-file speech-to-text tool built on [whisper.cpp](https://github.com/ggerganov/whisper.cpp) and the same Cosmopolitan packaging. It supports transcription and translation of audio files across all the same platforms, with no installation required.
 
 
 ## v0.10.0


### PR DESCRIPTION
Currently the link is broken
<img width="1756" height="852" alt="image" src="https://github.com/user-attachments/assets/887652bb-a3bc-49c0-81f8-5963053408da" />

After fix
<img width="1644" height="1184" alt="image" src="https://github.com/user-attachments/assets/3d6ddbe5-4b4c-48e5-af18-2140ee311c64" />
